### PR TITLE
move LTE PSM setup to SystemMode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,8 +158,9 @@ pub async fn init(mode: SystemMode) -> Result<(), Error> {
 
     let mut buffer = [0; 64];
     mode.create_at_command(&mut buffer)?;
-    mode.setup_psm().await?;
     at::send_at_bytes::<0>(&buffer).await?;
+
+    mode.setup_psm().await?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,8 +256,8 @@ impl SystemMode {
                 // Set Power Saving Mode (PSM)
                 at::send_at::<0>("AT+CPSMS=1").await?;
             } else {
-                // Set Power Saving Mode (PSM)
-                at::send_at::<0>("AT+CPSMS=1").await?;
+                // Turn off PSM
+                at::send_at::<0>("AT+CPSMS=0").await?;
             }
         }
         Ok(())

--- a/src/lte_link.rs
+++ b/src/lte_link.rs
@@ -43,8 +43,6 @@ impl LteLink {
             crate::at::send_at::<0>("AT%XDATAPRFL=0").await?;
             // Set UICC low power mode
             crate::at::send_at::<0>("AT+CEPPI=1").await?;
-            // Set Power Saving Mode (PSM)
-            crate::at::send_at::<0>("AT+CPSMS=1").await?;
             // Activate LTE without changing GNSS
             crate::at::send_at::<0>("AT+CFUN=21").await?;
         }


### PR DESCRIPTION
Not all SIM cards and networks do support PSM mode, if it is enabled then the network login fails and we get no link.
This is for example the case with iBASIS sim cards included with the Nordic Thingy:91.
This changes allows to set psm mode in SystemMode and not use hard-coded one.
Since LteLink is used internal by other functions the the Socker ones it is not possible to add that parameter to it's creation, and since it can be reused this could lead to inconsistent when the user calls in one program with different settings so I moved the AT command out of LteLink. 