### PR TITLE
Stop gnss when GnssStream is dropped

### DIFF
--- a/src/gnss.rs
+++ b/src/gnss.rs
@@ -173,6 +173,8 @@ impl Gnss {
 impl Drop for Gnss {
     fn drop(&mut self) {
         unsafe {
+            #[cfg(feature = "defmt")]
+            defmt::debug!("Disabling gnss");
             nrfxlib_sys::nrf_modem_at_printf(b"AT+CFUN=30".as_ptr());
         }
 
@@ -555,13 +557,11 @@ impl Stream for GnssStream {
 
 impl Drop for GnssStream {
     fn drop(&mut self) {
-        if !self.done {
-            unsafe {
-                #[cfg(feature = "defmt")]
-                defmt::debug!("Stopping gnss");
+        unsafe {
+            #[cfg(feature = "defmt")]
+            defmt::debug!("Stopping gnss");
 
-                nrfxlib_sys::nrf_modem_gnss_stop();
-            }
+            nrfxlib_sys::nrf_modem_gnss_stop();
         }
     }
 }


### PR DESCRIPTION
Fixes issue where GNSS fails on subsequent connects.

According to [nrfxlib docs](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrfxlib/nrf_modem/doc/gnss_interface.html) and my tests nrf_modem_gnss_stop() must be called regardless of whether the stream is done or not.

From docs:
![image](https://user-images.githubusercontent.com/93540369/221559260-b2d14095-3577-429f-a794-4d7e9647093c.png)

Also added logging entry for gnss disable
