### PR TITLE
Update nrf_modem_os_sem_take() 

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -501,11 +501,11 @@ pub extern "C" fn nrf_modem_os_sem_take(
             match timeout {
                 0 => return -(nrfxlib_sys::NRF_EAGAIN as i32),
                 nrfxlib_sys::NRF_MODEM_OS_FOREVER => {
-                    nrf_modem_os_busywait(1);
+                    nrf_modem_os_busywait(1000);
                 }
                 _ => {
                     timeout -= 1;
-                    nrf_modem_os_busywait(1);
+                    nrf_modem_os_busywait(1000);
                 }
             }
         }


### PR DESCRIPTION
Update nrf_modem_os_sem_take() to send 1 millisecond (1000 us) to the busywait function which takes microseconds not milliseconds.  The current version can prematurely timeout, specifically, during modem init.  