### PR TITLE
Fixes bug that clears GNSS_NOTICED_EVENTS after callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed bug that clears GNSS_NOTICED_EVENTS after callback
+
 ## 0.7.1 (2025-04-13)
 
 - Updated to nrfxlib-sys 2.9.2 which should make the docs compile again

--- a/src/gnss.rs
+++ b/src/gnss.rs
@@ -86,11 +86,12 @@ impl Gnss {
         #[cfg(feature = "defmt")]
         defmt::debug!("Starting gnss");
 
+        let gnss_stream = GnssStream::new(true, self);
         unsafe {
             nrfxlib_sys::nrf_modem_gnss_start();
         }
 
-        Ok(GnssStream::new(true, self))
+        Ok(gnss_stream)
     }
 
     pub fn start_continuous_fix(mut self, config: GnssConfig) -> Result<GnssStream, Error> {
@@ -111,11 +112,12 @@ impl Gnss {
         #[cfg(feature = "defmt")]
         defmt::debug!("Starting gnss");
 
+        let gnss_stream = GnssStream::new(false, self);
         unsafe {
             nrfxlib_sys::nrf_modem_gnss_start();
         }
 
-        Ok(GnssStream::new(false, self))
+        Ok(gnss_stream)
     }
 
     pub fn start_periodic_fix(
@@ -140,11 +142,12 @@ impl Gnss {
         #[cfg(feature = "defmt")]
         defmt::debug!("Starting gnss");
 
+        let gnss_stream = GnssStream::new(false, self);
         unsafe {
             nrfxlib_sys::nrf_modem_gnss_start();
         }
 
-        Ok(GnssStream::new(false, self))
+        Ok(gnss_stream)
     }
 
     fn apply_config(&mut self, config: GnssConfig) -> Result<(), Error> {


### PR DESCRIPTION
Issue was:

1. nrf_modem_gnss_start() is called, which triggers the callbacks
2. The callbacks set bits in GNSS_NOTICED_EVENTS
3. Then GnssStream::new() is called, which clears all those events

Symptom was:

Some first GNSS events were lost