### PR TITLE
Add optional support for embedded-nal-async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added embassy-net wrapper
 - Allow restricting address type of DNS queries with `resolve_dns()`
+- Add optional supports for the `TcpConnect` and `Dns` traits from `embedded-nal-async`
 
 ## 0.7.3 (2025-07-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added embassy-net wrapper
+- Allow restricting address type of DNS queries with `resolve_dns()`
 
 ## 0.7.3 (2025-07-23)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ embedded-io-async = "0.6.1"
 embassy-futures = { version = "0.1.1", optional = true }
 embassy-net-driver-channel = { version = "0.3.0", optional = true }
 heapless = { version = "0.8.0", optional = true }
+embedded-nal-async = { version = "0.8.0", optional = true }
 
 [build-dependencies]
 cc = { version = "1.2.18", optional = true }
@@ -58,6 +59,9 @@ embassy-net = [
   "dep:heapless",
 ]
 
+# Enable to add embedded-nal-async trait implementations.
+embedded-nal-async = ["dep:embedded-nal-async"]
+
 # Enable this feature when you're using an interrupt executor. 
 # You will need to give the interrupt number when initializing the modem so it can be ignored.
 # The modem's IPC interrupt should be higher than the os irq. (IPC should pre-empt the executor)
@@ -70,4 +74,4 @@ embassy-net = [
 os-irq = []
 
 [package.metadata.docs.rs]
-features = ["nrf9160"]
+features = ["nrf9160", "embedded-nal-async"]

--- a/README.md
+++ b/README.md
@@ -275,3 +275,9 @@ If you're facing problems with this library, you have the following tools for de
 The `embassy-net` feature enables a wrapper to be able to use the modem via embassy-net.
 
 An usage example is avaialble in `examples/embassy-net-tcp-client`.
+
+## embedded-nal-async
+
+The `embedded-nal-async` feature enables a `ModemNal` struct that implements traits from `embedded-nal-async`.
+
+Support is currently limited to DNS and unencrypted TCP.

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -2,7 +2,10 @@
 mod dns_blocking;
 
 #[cfg(not(feature = "dns-async"))]
-pub use dns_blocking::{get_host_by_name, get_host_by_name_with_cancellation};
+pub use dns_blocking::{
+    get_host_by_name, get_host_by_name_with_cancellation, resolve_dns,
+    resolve_dns_with_cancellation,
+};
 
 #[cfg(feature = "dns-async")]
 mod dns_async;
@@ -11,4 +14,75 @@ mod dns_async;
 mod dns_cache;
 
 #[cfg(feature = "dns-async")]
-pub use dns_async::{get_host_by_name, get_host_by_name_with_cancellation};
+pub use dns_async::{
+    get_host_by_name, get_host_by_name_with_cancellation, resolve_dns,
+    resolve_dns_with_cancellation,
+};
+
+/// A DNS query.
+///
+/// Pass to [`resolve_dns()`] or [`resolve_dns_with_cancellation()`].
+#[derive(Copy, Clone, Debug)]
+pub struct DnsQuery<'a> {
+    /// The hostname to resolve.
+    hostname: &'a str,
+
+    /// The desired address type.
+    addr_type: AddrType,
+}
+
+impl<'a> DnsQuery<'a> {
+    /// Create a new DNS query to resolve a given hostname.
+    ///
+    /// Does not restrict the address type to resolve.
+    pub fn new(hostname: &'a str) -> Self {
+        Self {
+            hostname,
+            addr_type: AddrType::Any,
+        }
+    }
+
+    /// Set the address type of the query.
+    ///
+    /// Can be used to ask only for an IPv4 or IPv6 address.
+    #[must_use = "this function returns a new query, it does not modify the existing one"]
+    pub fn with_address_type(self, addr_type: AddrType) -> Self {
+        let mut out = self;
+        out.addr_type = addr_type;
+        out
+    }
+
+    /// Get the hostname to resolve.
+    pub fn hostname(&self) -> &'a str {
+        self.hostname
+    }
+
+    /// Get the address type of the query.
+    pub fn addr_type(&self) -> AddrType {
+        self.addr_type
+    }
+}
+
+/// The address type for a DNS query.
+#[derive(Copy, Clone, Debug)]
+pub enum AddrType {
+    /// Resolve to an IPv4 or IPv6 address.
+    Any,
+
+    /// Resolve to an IPv4 address.
+    V4,
+
+    /// Resolve to an IPv6 address.
+    V6,
+}
+
+impl AddrType {
+    /// Check if the given IP address matches the address type.
+    fn addr_matches(&self, addr: core::net::IpAddr) -> bool {
+        match self {
+            Self::Any => true,
+            Self::V4 => matches!(addr, core::net::IpAddr::V4(_)),
+            Self::V6 => matches!(addr, core::net::IpAddr::V6(_)),
+        }
+    }
+}

--- a/src/embedded_nal_async.rs
+++ b/src/embedded_nal_async.rs
@@ -1,0 +1,55 @@
+use crate::DnsQuery;
+
+/// Modem struct implementing [`embedded-nal-async`] traits.
+///
+/// Only available with `feature = "embedded-nal-async"`.
+///
+/// NOTE: Reverse DNS lookups are not supported.
+/// The `get_host_by_address()` function will always report an error.
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ModemNal;
+
+impl embedded_nal_async::Dns for ModemNal {
+    type Error = crate::Error;
+
+    async fn get_host_by_name(
+        &self,
+        hostname: &str,
+        addr_type: embedded_nal_async::AddrType,
+    ) -> Result<core::net::IpAddr, Self::Error> {
+        let query = DnsQuery::new(hostname).with_address_type(addr_type.into());
+        crate::dns::resolve_dns(query).await
+    }
+
+    async fn get_host_by_address(
+        &self,
+        _addr: core::net::IpAddr,
+        _result: &mut [u8],
+    ) -> Result<usize, Self::Error> {
+        Err(crate::Error::ReverseDnsLookupNotSupported)
+    }
+}
+
+impl embedded_nal_async::TcpConnect for ModemNal {
+    type Error = crate::Error;
+
+    type Connection<'a> = crate::TcpStream;
+
+    async fn connect<'a>(
+        &'a self,
+        remote: core::net::SocketAddr,
+    ) -> Result<Self::Connection<'a>, Self::Error> {
+        crate::TcpStream::connect(remote).await
+    }
+}
+
+impl From<embedded_nal_async::AddrType> for crate::dns::AddrType {
+    fn from(value: embedded_nal_async::AddrType) -> Self {
+        match value {
+            embedded_nal_async::AddrType::Either => Self::Any,
+            embedded_nal_async::AddrType::IPv4 => Self::V4,
+            embedded_nal_async::AddrType::IPv6 => Self::V6,
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,8 @@ pub enum Error {
     DnsSocketError,
     #[cfg(feature = "dns-async")]
     DnsParseFailed,
+    #[cfg(feature = "embedded-nal-async")]
+    ReverseDnsLookupNotSupported,
 }
 
 impl embedded_io_async::Error for Error {
@@ -101,6 +103,8 @@ impl embedded_io_async::Error for Error {
             Error::DnsSocketError => embedded_io_async::ErrorKind::Other,
             #[cfg(feature = "dns-async")]
             Error::DnsParseFailed => embedded_io_async::ErrorKind::Other,
+            #[cfg(feature = "embedded-nal-async")]
+            Error::ReverseDnsLookupNotSupported => embedded_io_async::ErrorKind::Unsupported,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ mod dtls_socket;
 #[cfg(feature = "embassy-net")]
 pub mod embassy_net_modem;
 pub(crate) mod embedded_io_macros;
+#[cfg(feature = "embedded-nal-async")]
+pub mod embedded_nal_async;
 mod error;
 pub mod ffi;
 mod gnss;
@@ -39,6 +41,8 @@ pub use at_notifications::AtNotificationStream;
 pub use cancellation::CancellationToken;
 pub use dns::*;
 pub use dtls_socket::*;
+#[cfg(feature = "embedded-nal-async")]
+pub use embedded_nal_async::*;
 pub use error::Error;
 pub use gnss::*;
 pub use lte_link::LteLink;


### PR DESCRIPTION
This PR adds a `ModemNal` struct that implements `embedded_nal_async::{Dns, TcpConnect}`.

The DNS trait also has a function for reverse lookups. That one now always returns an error.

The UDP traits are not implemented because `embedded_nal_async` supports *unbound and unconnected* UDP sockets, and *bound and connected* UDP sockets. We have *bound and unconnected* sockets. This would be mostly fine, except we need to report our local address in a read, and there is currently no way to retrieve it.

I also added `DnsQuery`, `AddrType` and `resolve_dns[_with_cancellation]()` to support DNS queries with restricted address types in a backwards compatible way. The `DnsQuery` struct has only private fields, so it can be extended in the future.