### PR TITLE
feat: properly handle +CGCONTRDP when ipv6 is enabled

### DIFF
--- a/examples/embassy-net-tcp-client/Cargo.toml
+++ b/examples/embassy-net-tcp-client/Cargo.toml
@@ -26,7 +26,6 @@ embassy-nrf = { version = "0.7.0", features = [
 embassy-net = { version = "0.7.1", features = [
   "defmt",
   "tcp",
-  "proto-ipv4",
   "medium-ip",
 ] }
 
@@ -47,6 +46,13 @@ tinyrlibc = "0.5.0"
 
 # embassy-net branch
 nrf-modem = { path = "../../", features = ["embassy-net", "nrf9160", "defmt"] }
+
+[features]
+default = ["ipv4"]
+
+ipv4 = ["embassy-net/proto-ipv4"]
+ipv6 = ["embassy-net/proto-ipv6"]
+
 
 [profile.release]
 debug = 2

--- a/examples/embassy-net-tcp-client/src/bin/modem_tcp_client.rs
+++ b/examples/embassy-net-tcp-client/src/bin/modem_tcp_client.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use core::{net::IpAddr, str::FromStr};
+use core::str::FromStr;
 use cortex_m::peripheral::NVIC;
 use defmt::{debug, info, warn};
 use embassy_executor::Spawner;
-use embassy_net::{Ipv4Cidr, Stack, StackResources};
+use embassy_net::{Stack, StackResources};
 use embassy_nrf::{
     bind_interrupts,
     gpio::{Level, Output, OutputDrive},
@@ -27,6 +27,12 @@ extern crate tinyrlibc;
 
 pub type NetworkDevice = NetDriver<'static>;
 const MAX_CONCURRENT_SOCKETS: usize = 4;
+#[cfg(all(feature = "ipv4", not(feature = "ipv6")))]
+const PDP_TYPE: PdpType = PdpType::Ip;
+#[cfg(all(feature = "ipv4", feature = "ipv6"))]
+const PDP_TYPE: PdpType = PdpType::Ipv4v6;
+#[cfg(all(not(feature = "ipv4"), feature = "ipv6"))]
+const PDP_TYPE: PdpType = PdpType::Ipv6;
 
 #[doc(hidden)]
 pub struct InterruptHandler {
@@ -64,33 +70,44 @@ pub async fn control_task(
 
     control
         .run(|status| {
-            stack.set_config_v4(status_to_config(status));
+            let config = status_to_config(status);
+            #[cfg(feature = "ipv4")]
+            stack.set_config_v4(config.ipv4);
+            #[cfg(feature = "ipv6")]
+            stack.set_config_v6(config.ipv6);
         })
         .await
         .unwrap();
 }
-pub fn status_to_config(status: &Status) -> embassy_net::ConfigV4 {
-    let Some(IpAddr::V4(addr)) = status.ip1 else {
-        panic!("Unexpected IP address");
-    };
-
-    let gateway = match status.gateway {
-        Some(IpAddr::V4(addr)) => Some(addr),
-        _ => None,
-    };
-
-    let mut dns_servers = Vec::new();
-    for dns in status.dns.iter() {
-        if let IpAddr::V4(ip) = dns {
-            dns_servers.push(*ip).unwrap();
-        }
+pub fn status_to_config(status: &Status) -> embassy_net::Config {
+    let mut config = embassy_net::Config::default();
+    #[cfg(feature = "ipv4")]
+    if let Some(ref link) = status.ipv4_link {
+        let mut dns_servers = Vec::new();
+        dns_servers.extend(link.dns.iter().copied());
+        config.ipv4 = embassy_net::ConfigV4::Static(embassy_net::StaticConfigV4 {
+            address: embassy_net::Ipv4Cidr::new(link.ip, 32),
+            dns_servers,
+            gateway: link.gateway,
+        });
+    } else {
+        defmt::error!("No ipv4 config found");
     }
 
-    embassy_net::ConfigV4::Static(embassy_net::StaticConfigV4 {
-        address: Ipv4Cidr::new(addr, 32),
-        gateway,
-        dns_servers,
-    })
+    #[cfg(feature = "ipv6")]
+    if let Some(ref link) = status.ipv6_link {
+        let mut dns_servers = Vec::new();
+        dns_servers.extend(link.dns.iter().copied());
+        config.ipv6 = embassy_net::ConfigV6::Static(embassy_net::StaticConfigV6 {
+            address: embassy_net::Ipv6Cidr::new(link.ip, 128),
+            dns_servers,
+            gateway: link.gateway,
+        });
+    } else {
+        defmt::error!("No ipv6 config found");
+    }
+
+    config
 }
 
 pub async fn init<'a>(spawner: Spawner) -> (NetworkDevice, &'a context::Control<'a>) {
@@ -193,7 +210,7 @@ async fn main(spawner: Spawner) {
     let config = PdConfig {
         apn: None,
         pdn_auth: None,
-        pdp_type: PdpType::Ip,
+        pdp_type: PDP_TYPE,
     };
 
     spawner.spawn(net_task(runner)).unwrap();
@@ -215,7 +232,11 @@ async fn main(spawner: Spawner) {
         socket.set_timeout(Some(Duration::from_secs(10)));
 
         info!("Connecting...");
+        #[cfg(all(feature = "ipv4", not(feature = "ipv6")))]
         let host_addr = embassy_net::Ipv4Address::from_str("45.79.112.203").unwrap();
+        #[cfg(feature = "ipv6")]
+        let host_addr =
+            embassy_net::Ipv6Address::from_str("2600:3c01::f03c:91ff:feab:f98b").unwrap();
         if let Err(e) = socket.connect((host_addr, 4242)).await {
             warn!("connect error: {:?}", e);
             Timer::after_secs(10).await;

--- a/src/embassy_net_modem/context.rs
+++ b/src/embassy_net_modem/context.rs
@@ -4,7 +4,7 @@
 // Licence: https://github.com/embassy-rs/embassy/blob/main/LICENSE-APACHE
 // Source file: https://github.com/embassy-rs/embassy/blob/a8cb8a7fe1f594b765dee4cfc6ff3065842c7c6e/embassy-net-nrf91/src/context.rs
 
-use core::net::IpAddr;
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use core::str::FromStr;
 
 use at_commands::builder::CommandBuilder;
@@ -14,6 +14,8 @@ use embassy_time::{Duration, Timer};
 use heapless::Vec;
 
 use crate::{embassy_net_modem::CAP_SIZE, Error, LteLink};
+
+const DNS_VEC_SIZE: usize = 2;
 
 /// Provides a higher level API for controlling a given context.
 pub struct Control<'a> {
@@ -42,7 +44,7 @@ pub struct PdConfig<'a> {
 }
 
 /// Which type of communication happens on this PDP
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PdpType {
     /// IPv4
@@ -68,7 +70,7 @@ impl<'a> From<PdpType> for &'a str {
 }
 
 /// Authentication protocol.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
 pub enum AuthProt {
@@ -81,30 +83,179 @@ pub enum AuthProt {
 }
 
 /// Status of a given context.
-#[derive(PartialEq, Debug)]
+#[derive(Debug, Clone)]
 pub struct Status {
     /// Attached to APN or not.
     pub attached: bool,
-    /// IP if assigned. Can be IPv4 or IPv6. In dual stack mode this will always be an IPv4 address.
-    pub ip1: Option<IpAddr>,
-    /// Second IP if assigned, happens in dual stack where this will always be an IPv6 address.
-    pub ip2: Option<IpAddr>,
-    /// Gateway if assigned.
-    pub gateway: Option<IpAddr>,
-    /// DNS servers if assigned. The modem can return a maximum of 2 DNS servers.
-    pub dns: Vec<IpAddr, 2>,
+    /// IPv4 link.
+    pub ipv4_link: Option<LinkInfo<Ipv4Addr>>,
+    /// IPv6 link.
+    pub ipv6_link: Option<LinkInfo<Ipv6Addr>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LinkInfo<AddrType: Clone> {
+    /// IP if provided.
+    pub ip: AddrType,
+    /// Gateway if provided.
+    pub gateway: Option<AddrType>,
+    /// DNS servers if provided. The modem can return a maximum of 2 DNS servers.
+    pub dns: Vec<AddrType, DNS_VEC_SIZE>,
 }
 
 #[cfg(feature = "defmt")]
 impl defmt::Format for Status {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "attached: {}", self.attached);
-        if let Some(ip1) = &self.ip1 {
-            defmt::write!(f, ", ip1: {}", defmt::Debug2Format(&ip1));
+        if let Some(ipv4_link) = &self.ipv4_link {
+            defmt::write!(f, ", ipv4: {}", defmt::Debug2Format(&ipv4_link));
         }
-        if let Some(ip2) = &self.ip2 {
-            defmt::write!(f, ", ip2: {}", defmt::Debug2Format(&ip2));
+        if let Some(ipv6_link) = &self.ipv6_link {
+            defmt::write!(f, ", ipv6: {}", defmt::Debug2Format(&ipv6_link));
         }
+    }
+}
+
+/// The detected kind of address for this +CGCONTRDP message
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CgcontrdpOutputKind {
+    V4(CgcontrdpOutput<Ipv4Addr>),
+    V6(CgcontrdpOutput<Ipv6Addr>),
+}
+
+// Output of parsing function.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CgcontrdpOutput<AddrType> {
+    pub gateway: Option<AddrType>,
+    pub dns: Vec<AddrType, DNS_VEC_SIZE>,
+}
+
+// Parse one +CGCONTRDP: message, without the leading "+CGCONTRDP:".
+//
+// The challenge here is that the first section can either be IPv4 or IPv6 according to the documentation.
+// So we have to detect which IP version is used and ensure that all the values in this section use
+// the same version.
+fn parse_cgcontrdp_section(at_part: &str) -> Result<Option<CgcontrdpOutputKind>, Error> {
+    let (_cid, _bid, _apn, _mask, gateway, dns1, dns2, _, _, _, _, _mtu) =
+        CommandParser::parse(at_part.as_bytes())
+            .expect_int_parameter()
+            .expect_optional_int_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_string_parameter()
+            .expect_optional_int_parameter()
+            .expect_optional_int_parameter()
+            .expect_optional_int_parameter()
+            .expect_optional_int_parameter()
+            .expect_optional_int_parameter()
+            .finish()?;
+
+    // None means we didn't read a valid address yet.
+    let mut is_ipv4 = None;
+
+    let gateway = if let Some(ip) = gateway {
+        if ip.is_empty() {
+            None
+        } else {
+            let parsed = IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)?;
+            match parsed {
+                IpAddr::V4(_) => {
+                    is_ipv4.replace(true);
+                }
+                IpAddr::V6(_) => {
+                    is_ipv4.replace(false);
+                }
+            }
+            Some(parsed)
+        }
+    } else {
+        None
+    };
+
+    const {
+        assert!(
+            DNS_VEC_SIZE >= 2,
+            "Vec holding the DNS must have a capacity of at least 2"
+        )
+    }
+    let mut dns: Vec<IpAddr, DNS_VEC_SIZE> = Vec::new();
+    if let Some(ip) = dns1 {
+        if !ip.is_empty() {
+            let parsed = IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)?;
+            match parsed {
+                IpAddr::V4(_) => {
+                    is_ipv4.replace(true);
+                }
+                IpAddr::V6(_) => {
+                    is_ipv4.replace(false);
+                }
+            }
+            // Won't panic as we never push more than 2 elements
+            dns.push(parsed).unwrap();
+        }
+    }
+
+    if let Some(ip) = dns2 {
+        if !ip.is_empty() {
+            let parsed = IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)?;
+            match parsed {
+                IpAddr::V4(_) => {
+                    is_ipv4.replace(true);
+                }
+                IpAddr::V6(_) => {
+                    is_ipv4.replace(false);
+                }
+            }
+            // Won't panic as we never push more than 2 elements
+            dns.push(parsed).unwrap();
+        }
+    }
+
+    match is_ipv4 {
+        // IPv4 addresses
+        Some(true) => {
+            let mut dns_out: Vec<_, DNS_VEC_SIZE> = Vec::new();
+            for addr in dns.iter() {
+                // push will never panic, both Vecs are the same size.
+                dns_out.push(transform_to_v4(*addr)?).unwrap()
+            }
+            Ok(Some(CgcontrdpOutputKind::V4(CgcontrdpOutput {
+                gateway: gateway.map(transform_to_v4).transpose()?,
+                dns: dns_out,
+            })))
+        }
+        // IPv6 addersses
+        Some(false) => {
+            let mut dns_out: Vec<_, DNS_VEC_SIZE> = Vec::new();
+            for addr in dns.iter() {
+                // push will never panic, both Vecs are the same size.
+                dns_out.push(transform_to_v6(*addr)?).unwrap()
+            }
+            Ok(Some(CgcontrdpOutputKind::V6(CgcontrdpOutput {
+                gateway: gateway.map(transform_to_v6).transpose()?,
+                dns: dns_out,
+            })))
+        }
+        // There was no address specified in any of the fields
+        None => Ok(None),
+    }
+}
+
+// Returns the inner IPv4 address or errors out if it isn't one.
+fn transform_to_v4(ip: IpAddr) -> Result<Ipv4Addr, Error> {
+    match ip {
+        IpAddr::V4(ip) => Ok(ip),
+        IpAddr::V6(_) => Err(Error::AddrParseError),
+    }
+}
+
+// Returns the inner IPv6 address or errors out if it isn't one.
+fn transform_to_v6(ip: IpAddr) -> Result<Ipv6Addr, Error> {
+    match ip {
+        IpAddr::V4(_) => Err(Error::AddrParseError),
+        IpAddr::V6(ip) => Ok(ip),
     }
 }
 
@@ -251,10 +402,8 @@ impl<'a> Control<'a> {
         if !attached {
             return Ok(Status {
                 attached,
-                ip1: None,
-                ip2: None,
-                gateway: None,
-                dns: Vec::new(),
+                ipv4_link: None,
+                ipv6_link: None,
             });
         }
 
@@ -272,19 +421,36 @@ impl<'a> Control<'a> {
             .expect_identifier(b"\r\nOK")
             .finish()?;
 
-        let ip1 = if let Some(ip) = ip1 {
-            let ip = IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)?;
-            Some(ip)
-        } else {
-            None
-        };
+        let mut ipv4 = None;
+        let mut ipv6 = None;
 
-        let ip2 = if let Some(ip) = ip2 {
-            let ip = IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)?;
-            Some(ip)
-        } else {
-            None
-        };
+        // First position can be either IPv4 or IPv6.
+        if let Some(ip) = ip1 {
+            match IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)? {
+                IpAddr::V4(ip) => {
+                    let _ = ipv4.replace(ip);
+                }
+                IpAddr::V6(ip) => {
+                    let _ = ipv6.replace(ip);
+                }
+            };
+        }
+
+        // According to Nordic's doc, the second IP should always be IPv6.
+        if let Some(ip) = ip2 {
+            match IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)? {
+                IpAddr::V4(_) => {
+                    return Err(Error::AddrParseError);
+                }
+                IpAddr::V6(ip) => {
+                    // We replace the pevious IP address, we don't cover the case where there was already one.
+                    let _ = ipv6.replace(ip);
+                }
+            };
+        }
+
+        #[cfg(feature = "defmt")]
+        defmt::debug!("IPv4: {:?}, IPv6: {:?}", ipv4, ipv6);
 
         let op = CommandBuilder::create_set(&mut cmd, true)
             .named("+CGCONTRDP")
@@ -292,51 +458,76 @@ impl<'a> Control<'a> {
             .finish()
             .map_err(|s| Error::BufferTooSmall(Some(s)))?;
         let n = self.control.at_command(op).await;
-        let (_cid, _bid, _apn, _mask, gateway, dns1, dns2, _, _, _, _, _mtu) =
-            CommandParser::parse(n.as_bytes())
-                .expect_identifier(b"+CGCONTRDP: ")
-                .expect_int_parameter()
-                .expect_optional_int_parameter()
-                .expect_optional_string_parameter()
-                .expect_optional_string_parameter()
-                .expect_optional_string_parameter()
-                .expect_optional_string_parameter()
-                .expect_optional_string_parameter()
-                .expect_optional_int_parameter()
-                .expect_optional_int_parameter()
-                .expect_optional_int_parameter()
-                .expect_optional_int_parameter()
-                .expect_optional_int_parameter()
-                .expect_identifier(b"\r\nOK")
-                .finish()?;
 
-        let gateway = if let Some(ip) = gateway {
-            if ip.is_empty() {
-                None
-            } else {
-                Some(IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)?)
+        // In dual stack mode, the modem returns 2 `+CGCONTRDP:` lines, one for IPv4 and one for IPv6.
+        // This is too long to be parsed by the at_commands crate so we split it.
+        let mut sections = n.as_str().split("+CGCONTRDP: ");
+
+        // Separators at the start or end of a string are neighbored by empty strings.
+        // We consume the empty string.
+        sections.next();
+
+        let mut ipv4_link = ipv4.map(|ip| LinkInfo {
+            ip,
+            dns: Vec::new(),
+            gateway: None,
+        });
+
+        let mut ipv6_link = ipv6.map(|ip| LinkInfo {
+            ip,
+            dns: Vec::new(),
+            gateway: None,
+        });
+
+        // First section can either be IPv4 or IPv6. There should always be at least one +CGCONTRDP line.
+        let section = sections.next().ok_or(Error::UnexpectedAtResponse)?;
+        let output = parse_cgcontrdp_section(section)?;
+
+        match output {
+            Some(CgcontrdpOutputKind::V4(output)) => {
+                ipv4_link = ipv4_link.map(|l| LinkInfo {
+                    ip: l.ip,
+                    gateway: output.gateway,
+                    dns: output.dns,
+                });
             }
-        } else {
-            None
-        };
-
-        let mut dns = Vec::new();
-        if let Some(ip) = dns1 {
-            dns.push(IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)?)
-                .unwrap();
+            Some(CgcontrdpOutputKind::V6(output)) => {
+                ipv6_link = ipv6_link.map(|l| LinkInfo {
+                    ip: l.ip,
+                    gateway: output.gateway,
+                    dns: output.dns,
+                });
+            }
+            None => {
+                // No gateway or dns returned, we have nothing to add.
+            }
         }
 
-        if let Some(ip) = dns2 {
-            dns.push(IpAddr::from_str(ip).map_err(|_| Error::AddrParseError)?)
-                .unwrap();
+        // Second section means dual-stack, this should always be IPv6.
+        if let Some(section) = sections.next() {
+            let output = parse_cgcontrdp_section(section)?;
+
+            match output {
+                Some(CgcontrdpOutputKind::V4(_)) => {
+                    return Err(Error::UnexpectedAtResponse);
+                }
+                Some(CgcontrdpOutputKind::V6(output)) => {
+                    ipv6_link = ipv6_link.map(|l| LinkInfo {
+                        ip: l.ip,
+                        gateway: output.gateway,
+                        dns: output.dns,
+                    })
+                }
+                None => {
+                    // No gateway or dns returned, we have nothing to add.
+                }
+            }
         }
 
         Ok(Status {
             attached,
-            ip1,
-            ip2,
-            gateway,
-            dns,
+            ipv4_link,
+            ipv6_link,
         })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,7 @@ pub enum Error {
     DnsParseFailed,
     #[cfg(feature = "embedded-nal-async")]
     ReverseDnsLookupNotSupported,
-    /// The address resturned by the modem couldn't be parsed
+    /// The address returned by the modem couldn't be parsed
     #[cfg(feature = "embassy-net")]
     AddrParseError,
 }


### PR DESCRIPTION
I didn't read the spec correctly, turns out `+CGCONTRDP` returns two messages when it gets configured in dual stack mode. On the SIM I tested this happens when IPV6 or IPV4V6 PDN type is used.
I have to split the lines because `at_commands::parser::CommandParser` cannot handle that many fields.

This is breaking, it changes the struct returned on status change.